### PR TITLE
fix: add decoration to style-attribute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,15 @@ interface Colors {
   backgroundColor?: string;
 }
 
+interface Styles extends Colors {
+  fontWeight?: string;
+  opacity?: string;
+  fontStyle?: string;
+  visibility?: string;
+  textDecoration?: string;
+}
+
+
 /**
  * Create the style attribute.
  * @name createStyle
@@ -64,14 +73,38 @@ interface Colors {
  * @return {Object} returns the style object
  */
 function createStyle(bundle: AnserJsonEntry): Colors {
-  const style: Colors = {};
+  const style: Styles = {};
   if (bundle.bg) {
     style.backgroundColor = `rgb(${bundle.bg})`;
   }
   if (bundle.fg) {
     style.color = `rgb(${bundle.fg})`;
   }
-
+  switch (bundle.decoration) {
+    case 'bold':
+        style.fontWeight = 'bold';
+        break;
+    case 'dim':
+        style.opacity = '0.5';
+        break;
+    case 'italic':
+        style.fontStyle = 'italic';
+        break;
+    case 'hidden':
+        style.visibility = 'hidden';
+        break;
+    case 'strikethrough':
+        style.textDecoration = 'line-through';
+        break;
+    case 'underline':
+        style.textDecoration = 'underline';
+        break;
+    case 'blink':
+        style.textDecoration = 'blink';
+        break;
+    default:
+        break;
+  }
   return style;
 }
 


### PR DESCRIPTION
The `createStyle` function adds not only `Colors` to the attribute, but also `Decoration`.
Examples:

**bold**
```js
decoration === "bold"
```
=>
```html
<span style="font-weight: bold"></span>
```

**dim**
```js
decoration === "dim"
```
=>
```html
<span style="opacity: 0.5"></span>
```

**italic**
```js
decoration === "italic"
```
=>
```html
<span style="font-style: italic"></span>
```

**hidden**
```js
decoration === "hidden"
```
=>
```html
<span style="visibility: hidden"></span>
```

**strikethrough**
```js
decoration === "strikethrough"
```
=>
```html
<span style="text-decoration: line-through"></span>
```

**underline**
```js
decoration === "underline"
```
=>
```html
<span style="text-decoration: underline"></span>
```

**blink**
```js
decoration === "blink"
```
=>
```html
<span style="text-decoration: blink"></span>
```